### PR TITLE
Add modern frame to video player

### DIFF
--- a/index.html
+++ b/index.html
@@ -177,7 +177,7 @@
                   id="playr_captions_wrapper_0 my_video"
                 >
                   <div
-                    class="playr_video_container"
+                    class="playr_video_container video-frame"
                     id="playr_video_container_0"
                     style="border: 1px #ffffff; overflow: hidden"
                   >

--- a/index2.html
+++ b/index2.html
@@ -107,7 +107,7 @@
                     <div style="width:100%; margin:0">
                         <div class="playr_wrapper" id="playr_wrapper_0" tabindex="0">
                             <div class="playr_captions_wrapper" id="playr_captions_wrapper_0 my_video">
-                                <div class="playr_video_container" id="playr_video_container_0"
+                                <div class="playr_video_container video-frame" id="playr_video_container_0"
                                     style="border:1px #ffffff; overflow:hidden">
                                     <!-- <video class="playr_video" id="video">
                                         <source src="video/videoplayback.mp4" type="video/mp4">

--- a/style.css
+++ b/style.css
@@ -99,15 +99,13 @@ progress[value]::-webkit-progress-value {
 	background-color: #00BFFF;
 }
 
-
-
-
-
 #stage{background:#eee;width:200px;height:100px;overflow:hidden;
 	position:relative;margin:2em 0;}
 #stage span{font-size:20px;color:#666;display:block;padding:2em;}
-/* video{width:400px;height:300px;position:absolute;top:0;left:0;} */
-/* #controls{position:relative;width:400px;} */
-/* #change{position:absolute;right:-100px;top:-300px;width:100px;} */
-/* button{font-size:150%;text-align:center;display:block;} */
-/* #change button{width:60px;border:none;background:#fff;} */
+
+/* New CSS class for modern frame */
+.video-frame {
+  border: 2px solid #00BFFF;
+  padding: 10px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}


### PR DESCRIPTION
Add a modern frame to the video player in `index.html` and `index2.html`.

* **style.css**
  - Add a new CSS class `.video-frame` to create a modern frame for the video player.
  - Set the border, padding, and box-shadow properties for the `.video-frame` class.

* **index.html**
  - Add the `video-frame` class to the `div` with class `playr_video_container`.

* **index2.html**
  - Add the `video-frame` class to the `div` with class `playr_video_container`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hiyabh/Video_Player/pull/4?shareId=600e7f1c-0797-4fe8-bc40-b0f4b5f9281a).