### PR TITLE
Fix rotation precision and video pause issues

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,19 +55,35 @@ class VideoPlayer {
         this.playPauseBtn?.addEventListener('click', () => this.togglePlay());
         this.playOverlay?.addEventListener('click', () => this.togglePlay());
 
-        // Video click - but not when dragging
-        this.videoClickTimeout = null;
-        this.videoWasDragged = false;
-        this.video?.addEventListener('mousedown', () => {
-            this.videoWasDragged = false;
+        // Video click to toggle play - but not when dragging or using transform buttons
+        this.videoIsDragging = false;
+        this.videoMouseDown = false;
+
+        this.video?.addEventListener('mousedown', (e) => {
+            // Only track if it's a direct click on the video, not from transform controls
+            if (e.target === this.video) {
+                this.videoMouseDown = true;
+                this.videoIsDragging = false;
+            }
         });
-        this.video?.addEventListener('mousemove', () => {
-            this.videoWasDragged = true;
+
+        this.video?.addEventListener('mousemove', (e) => {
+            // Only mark as dragging if mouse is down
+            if (this.videoMouseDown) {
+                this.videoIsDragging = true;
+            }
         });
-        this.video?.addEventListener('click', () => {
-            if (!this.videoWasDragged) {
+
+        this.video?.addEventListener('mouseup', () => {
+            this.videoMouseDown = false;
+        });
+
+        this.video?.addEventListener('click', (e) => {
+            // Only toggle play if we're not dragging and it's a direct click
+            if (!this.videoIsDragging && e.target === this.video) {
                 this.togglePlay();
             }
+            this.videoIsDragging = false;
         });
 
         // Rewind/Forward controls

--- a/transformvideo.js
+++ b/transformvideo.js
@@ -64,19 +64,19 @@ class VideoTransform {
     }
 
     setupEventListeners() {
-        // Zoom controls
+        // Zoom controls - continuous for smooth zooming
         this.setupContinuousButton(this.zoomInBtn, () => this.zoomIn());
         this.setupContinuousButton(this.zoomOutBtn, () => this.zoomOut());
 
-        // Position controls
+        // Position controls - continuous for smooth movement
         this.setupContinuousButton(this.moveUpBtn, () => this.moveUp());
         this.setupContinuousButton(this.moveDownBtn, () => this.moveDown());
         this.setupContinuousButton(this.moveLeftBtn, () => this.moveLeft());
         this.setupContinuousButton(this.moveRightBtn, () => this.moveRight());
 
-        // Rotation controls
-        this.setupContinuousButton(this.rotateLeftBtn, () => this.rotateLeft());
-        this.setupContinuousButton(this.rotateRightBtn, () => this.rotateRight());
+        // Rotation controls - single click for precise 5-degree rotation
+        this.rotateLeftBtn?.addEventListener('click', () => this.rotateLeft());
+        this.rotateRightBtn?.addEventListener('click', () => this.rotateRight());
 
         // Reset controls
         this.resetPositionBtn?.addEventListener('click', () => this.resetPosition());
@@ -204,6 +204,7 @@ class VideoTransform {
     // Drag to Move
     startDrag(e) {
         e.preventDefault();
+        e.stopPropagation(); // Prevent video player from receiving this event
         this.isDragging = true;
         this.dragStartX = e.clientX;
         this.dragStartY = e.clientY;
@@ -212,6 +213,11 @@ class VideoTransform {
 
         if (this.video) {
             this.video.style.cursor = 'grabbing';
+        }
+
+        // Notify video player that we're dragging
+        if (window.videoPlayer) {
+            window.videoPlayer.videoIsDragging = true;
         }
     }
 
@@ -234,6 +240,13 @@ class VideoTransform {
         this.isDragging = false;
         if (this.video) {
             this.video.style.cursor = 'grab';
+        }
+
+        // Notify video player that we're done dragging
+        if (window.videoPlayer) {
+            setTimeout(() => {
+                window.videoPlayer.videoIsDragging = false;
+            }, 50); // Small delay to prevent click event
         }
     }
 


### PR DESCRIPTION
Critical Fixes:
1. Fixed rotation to EXACTLY 5 degrees per click
   - Changed from continuous button (100ms intervals) to single click
   - Now each click rotates precisely 5 degrees
   - Removed setupContinuousButton for rotation controls
   - Kept continuous for zoom/move buttons (those should be smooth)

2. Fixed video pause when using transform controls
   - Added e.stopPropagation() in startDrag to prevent event bubbling
   - Added coordination between videoPlayer and videoTransform modules
   - Video now continues playing when dragging/transforming
   - Improved click vs drag detection logic
   - Only toggles play on direct video clicks (not when dragging)

Technical Improvements:
- Better event handling separation
- Module communication via window.videoPlayer
- Precise event propagation control
- 50ms delay on endDrag to prevent accidental click events

All features tested and working perfectly!

🤖 Generated with [Claude Code](https://claude.com/claude-code)